### PR TITLE
Upgrade to Express 4

### DIFF
--- a/lib/content-types.js
+++ b/lib/content-types.js
@@ -11,39 +11,43 @@ function consumes() {
   var types = Array.prototype.slice.call(arguments)
   , middleware = makeConsumeMiddleware(types);
 
-  middleware.consumes = types;
-  middleware.params = [{
-    paramType: "header",
-    name: "Content-Type",
-    description: "The format of the request body",
-    dataType: "string",
-    required: true,
-    allowMultiple: false,
-    allowableValues: {
-      valueType: "LIST",
-      values: types
-    }
-  }];
-  middleware.models = [];
-  middleware.errorResponses = [
-    { code: 400, reason: "Invalid content-type" }
-  ];
+  middleware.swaggerInfo = {
+      consumes: types,
+      params: [
+        {
+            paramType: "header",
+            name: "Content-Type",
+            description: "The format of the request body",
+            dataType: "string",
+            required: true,
+            allowMultiple: false,
+            allowableValues: {
+                valueType: "LIST",
+                values: types
+            }
+        }
+    ],
+    models: [],
+    errorResponses: [
+        { code: 400, reason: "Invalid content-type" }
+    ]
+  };
   types.forEach(function(type) {
     if (contentTypes[type]) {
-      middleware.params.push({
+      middleware.swaggerInfo.params.push({
         paramType: "body",
         description: "Request body (" + type + ")",
         dataType: contentTypes[type].id,
         required: true,
         allowMultiple: false
       });
-      middleware.models.push(contentTypes[type]);
-      middleware.errorResponses.push({
+      middleware.swaggerInfo.models.push(contentTypes[type]);
+      middleware.swaggerInfo.errorResponses.push({
         code: 400,
         reason: "Body does not match schema for " + type
       });
     } else {
-      middleware.params.push({
+      middleware.swaggerInfo.params.push({
         paramType: "body",
         description: "Request body (" + type + ")",
         dataType: "string",
@@ -58,16 +62,16 @@ function consumes() {
 function validateAgainstSchema(mime, req, res, next) {
   if (contentTypes[mime]) {
     if (!req.body) {
-      return res.send(400, { error: "No request body specified" });
+      return res.status(400).send({ error: "No request body specified" });
     }
     var errors = jsonschema.validate(
-      req.body, 
+      req.body,
       contentTypes[mime]
     );
     if (errors.length > 0) {
-      res.send(400, { 
-        error: 'Body does not match schema for ' + mime, 
-        errors: errors 
+      res.status(400).send({
+        error: 'Body does not match schema for ' + mime,
+        errors: errors
       });
       return;
     }
@@ -76,7 +80,7 @@ function validateAgainstSchema(mime, req, res, next) {
 }
 
 function makeConsumeMiddleware(types) {
-  return function consumesMiddleware(req, res, next) {
+  return function swaggerConsumes(req, res, next) {
 
     if (req.header('content-type')) {
 
@@ -86,27 +90,29 @@ function makeConsumeMiddleware(types) {
         req.mime = req.mime || mime;
         validateAgainstSchema(mime, req, res, next);
       } else {
-        res.send(400, { error: 'Invalid content-type: ' + mime });
+        res.status(400).send({ error: 'Invalid content-type: ' + mime });
       }
     } else {
-      res.send(400, { error: 'No content-type specified' });
+      res.status(400).send({ error: 'No content-type specified' });
     }
   };
 }
 
 function produces() {
   var types = Array.prototype.slice.call(arguments)
-  , middleware = function producesMiddleware(req, res, next) {
+  , middleware = function swaggerProduces(req, res, next) {
     res.set('content-type', types[0]);
     next();
   };
 
-  middleware.produces = types;
-  middleware.models = [];
+  middleware.swaggerInfo = {
+      produces: types,
+      models: []
+  };
   types.forEach(function(type) {
     if (contentTypes[type]) {
-      middleware.models.push(contentTypes[type]);
-      middleware.responseClass = contentTypes[type].id;
+      middleware.swaggerInfo.models.push(contentTypes[type]);
+      middleware.swaggerInfo.responseClass = contentTypes[type].id;
     }
   });
   return middleware;

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -1,9 +1,20 @@
 "use strict";
-module.exports = function describe(nickname, shortDescription, longDescription) {
-  var middleware = function describeMiddleware(req, res, next) { next(); };
-  middleware.nickname = nickname;
-  middleware.shortDescription = shortDescription;
-  middleware.longDescription = longDescription;
+var thing = require('lodash');
 
+module.exports = function describe(nickname, shortDescription, longDescription) {
+  var description = {};
+  if (thing.isObject(nickname)) {
+      var info = nickname;
+      description.nickname = info.nickname || info.nick;
+      description.shortDescription = info.shortDescription || info.short;
+      description.longDescription = info.longDescription || info.long;
+  }
+  if (thing.isString(nickname)) {
+      description.nickname = nickname
+      description.shortDescription = shortDescription;
+      description.longDescription = longDescription;
+  }
+  var middleware = function swaggerInfo(req, res, next) { next(); };
+  middleware.swaggerInfo = description;
   return middleware;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@
 var express = require('express')
 , path = require('path')
 , contentTypes = require('./content-types')
+, _ = require('lodash')
+, thing = _
+
 ;
 
 exports.describe = require('./describe');
@@ -33,7 +36,7 @@ function api(options, routes) {
     }
   });
 
-  doc.apis = apiPaths.map(function(path) { 
+  doc.apis = apiPaths.map(function(path) {
     return {
       path: path,
       description: "none"
@@ -41,8 +44,8 @@ function api(options, routes) {
   });
 
   docs.push({ path: docPath, doc: doc });
-  
-  return docs.concat(makeApis(docPath, options, apis)); 
+
+  return docs.concat(makeApis(docPath, options, apis));
 }
 
 function byPath(a, b) {
@@ -60,7 +63,7 @@ function makeApis(docPath, options, apis) {
     doc.apis = routes.map(routeToApi).sort(byPath).reduce(function(accum, current) {
       var previous = accum[accum.length - 1];
       if (previous && previous.path === current.path) {
-        previous.operations = previous.operations.concat(current.operations);        
+        previous.operations = previous.operations.concat(current.operations);
       } else {
         accum.push(current);
       }
@@ -80,7 +83,7 @@ function makeApis(docPath, options, apis) {
 }
 
 function routeToApi(route) {
-  var api = { 
+  var api = {
     path: route.path.replace(/:(\w+)/g, "{$1}"),
     description: shortDescription(route),
     operations: [{
@@ -94,70 +97,49 @@ function routeToApi(route) {
       responseClass: responseClass(route)
     }]
   };
-
   return api;
 }
 
-function findDescription(type, route) {
-  return find(type, route, "");
-}
-
-function findArray(type, route) {
-  var result = [];
-  route.callbacks.forEach(function(cb) {
-    if (cb[type]) {
-      result = result.concat(cb[type]);
-    }
-  });
-  return result;
-}
-
 function find(type, route, defaultValue) {
-  var result = defaultValue;
-  route.callbacks.forEach(function(cb) {
-    if (cb[type]) {
-      result = cb[type];
-    }
-  });
-  return result;
+  return route.swagger[type] || defaultValue;
 }
 
 function models(route) {
-  return findArray("models", route);
+    return find("models", route, []);
 }
 
 function responseClass(route) {
-  return findDescription("responseClass", route);
+    return find("responseClass", route, "");
 }
 
 function nickname(route) {
-  return findDescription("nickname", route);
+    return find("nickname", route, "");
 }
 
 function parameters(route) {
-  return findArray("params", route);
+    return find("params", route, []);
 }
 
 function errorResponses(route) {
-  return findArray("errorResponses", route);
+    return find("errorResponses", route, []);
 }
 
 function shortDescription(route) {
-  return findDescription("shortDescription", route);
+    return find("shortDescription", route, "");
 }
 
 function longDescription(route) {
-  return findDescription("longDescription", route);
+    return find("longDescription", route, "");
 }
 
 function consumesArray(route) {
-  return findArray("consumes", route);
+    return find("consumes", route, []);
 }
 
 function producesArray(route) {
-  return findArray("produces", route);
+    return find("produces", route, []);
 }
-  
+
 function makeBaseDoc(options) {
   return {
     apiVersion: ((options && options.version) || "1.0"),
@@ -171,24 +153,49 @@ function routeWithDescription(route) {
   return route.callbacks.filter(function(cb) { return cb.nickname; }).length > 0;
 }
 
-function documentedRoutes(app) {
-  var routes = [];
-  
-  Object.keys(app.routes).forEach(function(method) {
-    var interestingRoutes = app.routes[method].filter(routeWithDescription);
-    routes = routes.concat(interestingRoutes);
-  });
+function documentedRoutes(appRoutes) {
 
-  return routes;
+    var documented = appRoutes.filter(function (route) {
+        return thing.isObject(route.route)
+            && route.route.stack.filter(function (item) {
+            return thing.isFunction(item.handle)
+                && item.handle.swaggerInfo
+        }).length > 0
+    });
+
+    var summarized = documented.map(function(route) {
+        return {
+            path: route.route.path,
+            swagger: route.route.stack.filter(function (item) {
+                return thing.isFunction(item.handle)
+                    && item.handle.swaggerInfo
+                }).map(function(item) {
+                    return (
+                        item.handle.swaggerInfo
+                        )
+                }).reduce(function(result, item) {
+                    var existing = result.models;
+                    var combined = _.extend(result, item);
+                    combined.models = _.uniq(_.flatten([existing, item.models || []], true));
+                    return combined;
+                }, { models: []}),
+            method: _.last(route.route.stack).method
+        }
+    });
+
+    return summarized;
+
 }
 
 function swagger(appToDocument, options) {
-  if (!(appToDocument && Object.keys(appToDocument.routes).length)) {
+  var routes = appToDocument._router ? appToDocument._router.stack : appToDocument.stack;
+
+  if (!(appToDocument && routes  && routes.length > 0)) {
     throw new Error("Either you didn't pass in an express app, or that app had no routes defined");
   }
 
   var app = express()
-  , apiDocs = api(options, documentedRoutes(appToDocument));
+  , apiDocs = api(options, documentedRoutes(routes));
 
   apiDocs.forEach(function(apiDoc) {
     app.get(apiDoc.path, function(req, res) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -4,15 +4,15 @@ var joi = require('joi');
 function makeValidator(originalSchema) {
   var schema = convertHeadersToLowerCase(originalSchema);
 
-  return function paramValidator(req, res, next) {
+  return function swaggerValidation(req, res, next) {
     var errors = joi.validate(
-      onlySchemaFields(merge(req.params, req.query, req.headers), schema), 
+      onlySchemaFields(merge(req.params, req.query, req.headers), schema),
       schema
     );
     if (errors) {
-      res.send(400, { 
-        error: errors.message, 
-        details: "http://www.youtube.com/watch?v=WOdjCb4LwQY" 
+      res.status(400).send({
+        error: errors.message,
+        details: "http://www.youtube.com/watch?v=WOdjCb4LwQY"
       });
     } else {
       next();
@@ -127,10 +127,13 @@ function convertJoiTypesToSwagger(schema) {
 
 module.exports = function validate(schema) {
   var middleware = makeValidator(convertHeadersToLowerCase(schema));
-  middleware.params = convertJoiTypesToSwagger(schema);
-  middleware.errorResponses = [
-    { code: 400, reason: "Invalid parameters specified" }
-  ];
+
+  middleware.swaggerInfo = {
+      params: convertJoiTypesToSwagger(schema),
+        errorResponses: [
+            { code: 400, reason: "Invalid parameters specified" }
+        ]
+      };
   return middleware;
 };
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "flair-ui": "0.0.3"
   },
   "dependencies": {
-    "express": "~3.2.3",
+    "express": "^4.8.8",
     "joi": "~0.3.4",
-    "jsonschema": "~0.3.2"
+    "jsonschema": "~0.3.2",
+    "lodash": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flair-doc",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "Swagger-compliant REST API documentation generator",
   "main": "lib/index.js",
   "scripts": {
@@ -17,9 +17,11 @@
     "documentation"
   ],
   "author": "Gareth Jones <gareth.jones@sensis.com.au>",
+  "contributors": [
+      "Hans Donner <hans@hansdonner.nl>"
+  ],
   "license": "BSD",
   "readmeFilename": "README.md",
-  "gitHead": "ddc08045fcc23df6ae74c954c96179934b4daf29",
   "devDependencies": {
     "mocha": "~1.9.0",
     "should": "~1.2.2",

--- a/test/flair-test.js
+++ b/test/flair-test.js
@@ -580,7 +580,7 @@ describe('flair', function() {
       it('should set the content-type of the response', function(done) {
         supertest(app)
           .get('/pants')
-          .expect('Content-Type', 'application/vnd.pants+json')
+          .expect('Content-Type', 'application/vnd.pants+json; charset=utf-8')
           .expect(200, done);
       });
 

--- a/test/flair-test.js
+++ b/test/flair-test.js
@@ -58,7 +58,7 @@ describe('flair', function() {
 
     describe('when provided with an api version', function() {
       var app = flair.swagger(appToDescribe, { version: "0.5" });
-      
+
       it('should respond with that version', function(done) {
         supertest(app)
           .get('/api-doc')
@@ -79,7 +79,7 @@ describe('flair', function() {
           .get('/api-doc')
           .expect(404, done);
       });
-      
+
       it('should respond on the docPath', function(done) {
         supertest(app)
           .get('/something')
@@ -89,7 +89,7 @@ describe('flair', function() {
 
     describe('when provided with a base path', function() {
       var app = flair.swagger(appToDescribe, { basePath: "/pants" });
-      
+
       it('should respond with that version and basePath', function(done) {
         supertest(app)
           .get('/api-doc')
@@ -106,13 +106,13 @@ describe('flair', function() {
     describe('when a route has been described', function() {
       var app = express(), flairedApp;
       app.get(
-        '/pants', 
+        '/pants',
         flair.describe("getPants", "short pants", "longer pants"),
         function (req, res) {
           res.send("I'm still here.");
         }
       );
-      
+
       flairedApp = flair.swagger(app);
 
       it('should include the top-level resource path in the apis array', function(done) {
@@ -239,9 +239,9 @@ describe('flair', function() {
       it('should validate the parameters', function(done) {
         supertest(app)
           .get('/pants/cheese')
-          .expect(400, { 
-            error: "not valid", 
-            details: "http://www.youtube.com/watch?v=WOdjCb4LwQY" 
+          .expect(400, {
+            error: "the value of id must be a number",
+            details: "http://www.youtube.com/watch?v=WOdjCb4LwQY"
           }, done);
       });
 
@@ -250,7 +250,7 @@ describe('flair', function() {
           .get('/pants/1')
           .expect(200, 'blah', done);
       });
-      
+
       it('should add a 400 bad request to the error responses', function(done) {
         supertest(flairedApp)
           .get('/api-doc/pants')
@@ -263,12 +263,12 @@ describe('flair', function() {
             done(err);
           });
       });
-      
+
     });
 
     describe('when an app with multiple operations on a resource is described', function() {
       var app = express(), flairedApp;
-      
+
       app.get(
         '/pants/:id',
         flair.describe("getPants", "short pants", "long pants"),
@@ -339,7 +339,7 @@ describe('flair', function() {
             }
           });
       });
-      
+
       it('should set the consumes value of the operation', function(done) {
         supertest(flairedApp)
           .get('/api-doc/pants')
@@ -443,7 +443,7 @@ describe('flair', function() {
           required: true
         }
       );
-      
+
       app.use(flair.jsonBodyParser());
       app.post(
         '/pants',
@@ -496,7 +496,7 @@ describe('flair', function() {
             done(err);
           });
       });
-      
+
       it('should not specify the responseClass in the operation', function(done) {
         supertest(flairedApp)
           .get('/api-doc/pants')

--- a/test/joi-types-test.js
+++ b/test/joi-types-test.js
@@ -11,7 +11,7 @@ describe('flair', function() {
     var validate = flair.validate({
       thing: joi.types.String().notes("path").description("it's a thing"),
       whatsit: joi.types.String()
-    });
+    }).swaggerInfo;
 
     it('should pick up the name from object property', function() {
       validate.params[0].name.should.equal('thing');
@@ -38,7 +38,7 @@ describe('flair', function() {
       var intValidator = flair.validate({
         thing: joi.types.Number().integer().min(1).max(10).required(),
         another: joi.types.Number().integer().valid(1,3,5,7)
-      });
+      }).swaggerInfo;
 
       it('should be converted to swagger params', function() {
         intValidator.params[0].dataType.should.equal("int");
@@ -68,7 +68,8 @@ describe('flair', function() {
       var stringValidator = flair.validate({
         thing: joi.types.String().required(),
         another: joi.types.String().valid("cheese", "biscuits")
-      });
+      }).swaggerInfo;
+
       it('should be converted to swagger params', function() {
         stringValidator.params[0].dataType.should.equal("string");
         stringValidator.params[0].paramType.should.equal("query");
@@ -90,7 +91,7 @@ describe('flair', function() {
       var booleanValidator = flair.validate({
         thing: joi.types.Boolean(),
         another: joi.types.Boolean().required()
-      });
+      }).swaggerInfo;
 
       it('should be converted to swagger params', function() {
         booleanValidator.params[0].dataType.should.equal("boolean");
@@ -108,7 +109,8 @@ describe('flair', function() {
         thing: joi.types.Number().float().required(),
         another: joi.types.Number().float().min(0).max(1),
         onemore: joi.types.Number().float().valid(0.25, 0.5, 0.75)
-      });
+      }).swaggerInfo;
+
       it('should be converted to swagger params', function() {
         doubleValidator.params[0].dataType.should.eql("double");
         doubleValidator.params[0].paramType.should.eql("query");
@@ -138,7 +140,7 @@ describe('flair', function() {
       var dateValidator = flair.validate({
         thing: joi.types.String().date(),
         another: joi.types.String().date().required()
-      });
+      }).swaggerInfo;
 
       it('should be converted to swagger params', function() {
         dateValidator.params[0].dataType.should.equal("Date");
@@ -160,7 +162,7 @@ describe('flair', function() {
         minMax: joi.types.Array().includes(
           joi.types.Number().integer().min(5).max(20)
         )
-      });
+      }).swaggerInfo;
 
       it('should pick up multiple values with sensible defaults', function() {
         validate.params[0].should.eql({
@@ -183,9 +185,9 @@ describe('flair', function() {
       });
 
 
-      /* 
+      /*
          These two tests are pending, waiting for joi to handle Array
-         constraints properly 
+         constraints properly
       */
       it('should pick up the data type'/*, function() {
         validate.params[0].dataType.should.equal('string');


### PR DESCRIPTION
And drop support for Express 3 (they can still use the older version).

The implementation (internals) has changed, the public api is backward compatible. 
